### PR TITLE
Fix cover position updates for battery-powered devices

### DIFF
--- a/ts0601_cover_custom.py
+++ b/ts0601_cover_custom.py
@@ -328,6 +328,7 @@ class TuyaZemismartSmartCover0601_3_battery(TuyaWindowCover):
                     Groups.cluster_id,
                     Scenes.cluster_id,
                     ZemismartManufClusterBattery,
+                    TuyaManufacturerWindowCover,
                     TuyaWindowCoverControl,
                     TuyaPowerConfigurationCluster,
                 ],


### PR DESCRIPTION
## Summary
- Added `TuyaManufacturerWindowCover` to INPUT_CLUSTERS for `TuyaZemismartSmartCover0601_3_battery` class
- Enables position reporting while maintaining battery percentage functionality
- Fixes issue where battery-powered covers (models _TZE200_68nvbio9, _TZE200_pw7mji0l, _TZE200_cf1sl3tj) were not updating their position status

## Test plan
- [x] Deploy updated quirk to Home Assistant
- [x] Verify battery percentage continues to report correctly
- [x] Verify cover position updates when device moves
- [x] Test open/close/stop commands still work correctly